### PR TITLE
Fix time rendered incorrectly

### DIFF
--- a/gatsby_site/src/components/EventsContainer/EventItem/Components/TimeBox.js
+++ b/gatsby_site/src/components/EventsContainer/EventItem/Components/TimeBox.js
@@ -46,14 +46,11 @@ const TimeBox = ({ starttime, endtime, eventIndex }) => {
   const { toggleSelectedEvent } = globalActions;
 
   let singleTime = null;
-  let plusTime = null;
   if (starttime === endtime) {
     if (!starttime || !endtime) {
       singleTime = '-';
-    } else if (starttime.includes('allday')) {
+    } else if (starttime.includes('(All day)')) {
       singleTime = 'All day';
-    } else {
-      plusTime = dtutil.getAssumedEndtime(endtime);
     }
   }
 
@@ -67,7 +64,7 @@ const TimeBox = ({ starttime, endtime, eventIndex }) => {
                 {dtutil.getTime(starttime)}
               </StyledTime>
               <StyledTime>
-                {plusTime || dtutil.getTime(endtime)}
+                {endtime ? dtutil.getTime(endtime) : null}
               </StyledTime>
             </React.Fragment>
           )


### PR DESCRIPTION
`allday` is changed to `(All day)` in backend, we need to reflect that in frontend too.

We will no longer assume `endtime`, will show only `starttime` instead.