### PR TITLE
fix(Helmet): Fix helmet doesn't load meta tags

### DIFF
--- a/gatsby_site/gatsby-config.js
+++ b/gatsby_site/gatsby-config.js
@@ -32,5 +32,6 @@ module.exports = {
       },
     },
     'gatsby-transformer-json',
+    'gatsby-plugin-react-helmet',
   ],
 };


### PR DESCRIPTION
We need to also add the helmet plugin in gatsby-config so that the meta
tags are included from the server.